### PR TITLE
Router details modal init

### DIFF
--- a/frontend/src/Components/RouterDetailsModal/RouterDetailsModal.tsx
+++ b/frontend/src/Components/RouterDetailsModal/RouterDetailsModal.tsx
@@ -1,0 +1,69 @@
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Stack,
+  Typography,
+  Divider,
+} from "@mui/material";
+import { RouterItem } from "../../types";
+import { EnterpriseRouterDetails } from "./types/EnterpriseRouterDetails";
+import { HomeRouterDetails } from "./types/HomeRouterDetails";
+import { WifiRouterDetails } from "./types/WifiRouterDetails";
+import dayjs from "dayjs";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  router: RouterItem | null;
+}
+
+export const RouterDetailsModal = ({ open, onClose, router }: Props) => {
+  if (!router) return null;
+
+  const renderTypeDetails = () => {
+    switch (router.type) {
+      case "enterprise":
+        return <EnterpriseRouterDetails router={router} />;
+      case "home":
+        return <HomeRouterDetails router={router} />;
+      case "wifi":
+        return <WifiRouterDetails router={router} />;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>{router.name}</DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={2}>
+          <Typography variant="body2" color="textSecondary">
+            ID: {router.id}
+          </Typography>
+          <Typography>Type: {router.type}</Typography>
+          <Typography>
+            Coordinates:
+            {`${router.coordinates.latitude}, ${router.coordinates.longitude}`}
+          </Typography>
+          <Typography>
+            Updated At: {dayjs(router.updatedAt).format("YYYY-MM-DD HH:mm")}
+          </Typography>
+          <Typography>
+            Created At: {dayjs(router.createdAt).format("YYYY-MM-DD HH:mm")}
+          </Typography>
+          <Divider />
+          {renderTypeDetails()}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} variant="contained">
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/frontend/src/Components/RouterDetailsModal/types/EnterpriseRouterDetails.tsx
+++ b/frontend/src/Components/RouterDetailsModal/types/EnterpriseRouterDetails.tsx
@@ -1,0 +1,17 @@
+import { EnterpriseRouter } from "../../../types";
+import { Stack, Typography } from "@mui/material";
+
+export const EnterpriseRouterDetails = ({
+  router,
+}: {
+  router: EnterpriseRouter;
+}) => (
+  <Stack spacing={1}>
+    <Typography fontWeight="bold">Enterprise Details</Typography>
+    <Typography>Port Count: {router.portCount}</Typography>
+    <Typography>Throughput: {router.throughputGbps} Gbps</Typography>
+    <Typography>
+      Supported Protocols: {router.supportedProtocols.join(", ")}
+    </Typography>
+  </Stack>
+);

--- a/frontend/src/Components/RouterDetailsModal/types/HomeRouterDetails.tsx
+++ b/frontend/src/Components/RouterDetailsModal/types/HomeRouterDetails.tsx
@@ -1,0 +1,13 @@
+import { HomeRouter } from "../../../types";
+import { Stack, Typography } from "@mui/material";
+
+export const HomeRouterDetails = ({ router }: { router: HomeRouter }) => (
+  <Stack spacing={1}>
+    <Typography fontWeight="bold">Home Router Details</Typography>
+    <Typography>Connected Devices: {router.connectedDevices}</Typography>
+    <Typography>
+      Parental Controls Enabled: {router.parentalControlsEnabled ? "Yes" : "No"}
+    </Typography>
+    <Typography>Max Bandwidth: {router.maxBandwidthMbps} Mbps</Typography>
+  </Stack>
+);

--- a/frontend/src/Components/RouterDetailsModal/types/WifiRouterDetails.tsx
+++ b/frontend/src/Components/RouterDetailsModal/types/WifiRouterDetails.tsx
@@ -1,0 +1,12 @@
+import { WifiRouter } from "../../../types";
+import { Stack, Typography } from "@mui/material";
+
+export const WifiRouterDetails = ({ router }: { router: WifiRouter }) => (
+  <Stack spacing={1}>
+    <Typography fontWeight="bold">WiFi Access Point</Typography>
+    <Typography>WiFi Channels: {router.wifiChannels.join(", ")}</Typography>
+    <Typography>
+      Dual Band Support: {router.supportsDualBand ? "Yes" : "No"}
+    </Typography>
+  </Stack>
+);

--- a/frontend/src/Components/RoutersTable/RoutersTable.tsx
+++ b/frontend/src/Components/RoutersTable/RoutersTable.tsx
@@ -1,49 +1,46 @@
-import { Skeleton, Table, TableBody, TableCell, TableRow } from "@mui/material";
 import dayjs from "dayjs";
+import { Table, TableBody, TableCell, TableRow } from "@mui/material";
 import { RouterItem, SortDirection, SortField } from "../../types";
 import { RoutersTableHead } from "./RoutersTableHead/RoutersTableHead";
+import { RoutersTableLoader } from "./RoutersTableLoader/RoutersTableLoader";
 
 interface RoutersTableProps {
   isLoading: boolean;
-  handleSort: (field: SortField) => void;
   filteredAndSortedRouters: RouterItem[];
   sortField: SortField;
   sortDirection: SortDirection;
+  handleSort: (field: SortField) => void;
+  onRowClick: (router: RouterItem) => void;
 }
 
 export const RoutersTable: React.FC<RoutersTableProps> = ({
   filteredAndSortedRouters,
-  handleSort,
   isLoading,
   sortField,
   sortDirection,
+  onRowClick,
+  handleSort,
 }) => {
-  return (
-    <>
-      {isLoading ? (
-        Array.from({ length: 3 }).map((_, i) => (
-          <Skeleton key={i} variant="rectangular" height={60} sx={{ mb: 2 }} />
-        ))
-      ) : (
-        <Table>
-          <RoutersTableHead
-            handleSort={handleSort}
-            sortDirection={sortDirection}
-            sortField={sortField}
-          />
-          <TableBody>
-            {filteredAndSortedRouters.map((router) => (
-              <TableRow key={router.id}>
-                <TableCell>{router.name}</TableCell>
-                <TableCell>{router.type}</TableCell>
-                <TableCell>
-                  {dayjs(router.updatedAt).format("YYYY-MM-DD HH:mm")}
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      )}
-    </>
+  return isLoading ? (
+    <RoutersTableLoader />
+  ) : (
+    <Table>
+      <RoutersTableHead
+        handleSort={handleSort}
+        sortDirection={sortDirection}
+        sortField={sortField}
+      />
+      <TableBody>
+        {filteredAndSortedRouters.map((router) => (
+          <TableRow key={router.id} onClick={() => onRowClick(router)}>
+            <TableCell>{router.name}</TableCell>
+            <TableCell>{router.type}</TableCell>
+            <TableCell>
+              {dayjs(router.updatedAt).format("YYYY-MM-DD HH:mm")}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
   );
 };

--- a/frontend/src/Components/RoutersTable/RoutersTableLoader/RoutersTableLoader.tsx
+++ b/frontend/src/Components/RoutersTable/RoutersTableLoader/RoutersTableLoader.tsx
@@ -1,0 +1,11 @@
+import { Skeleton } from "@mui/material";
+
+export const RoutersTableLoader = () => {
+  return (
+    <>
+      {Array.from({ length: 10 }).map((_, i) => (
+        <Skeleton key={i} variant="rectangular" height={50} sx={{ mb: 2 }} />
+      ))}
+    </>
+  );
+};

--- a/frontend/src/Pages/Routers/Routers.tsx
+++ b/frontend/src/Pages/Routers/Routers.tsx
@@ -4,11 +4,13 @@ import { useMemo, useState } from "react";
 import { useSortRouters } from "../../hooks/useSortRouters";
 import { RoutersFilter } from "../../Components/RoutersTable/RoutersFilter/RoutersFilter";
 import { RoutersTable } from "../../Components/RoutersTable/RoutersTable";
+import { useRouterDetailsModal } from "../../hooks/useRouterDetailsModal";
 
 export const Routers = () => {
   const { error, isLoading, routersData } = useRouterList();
   const [filterType, setFilterType] = useState<string>("all");
   const { handleSort, sortDirection, sortField } = useSortRouters();
+  const { handleRowClick, renderRouterDetailsModal } = useRouterDetailsModal();
 
   const filteredAndSortedRouters = useMemo(() => {
     let result = [...routersData];
@@ -42,11 +44,13 @@ export const Routers = () => {
       )}
       <RoutersTable
         filteredAndSortedRouters={filteredAndSortedRouters}
-        handleSort={handleSort}
         isLoading={isLoading}
         sortDirection={sortDirection}
         sortField={sortField}
+        handleSort={handleSort}
+        onRowClick={handleRowClick}
       />
+      {renderRouterDetailsModal}
     </Box>
   );
 };

--- a/frontend/src/hooks/useRouterDetailsModal.tsx
+++ b/frontend/src/hooks/useRouterDetailsModal.tsx
@@ -1,0 +1,28 @@
+import { useState } from "react";
+import { RouterItem } from "../types";
+import { RouterDetailsModal } from "../Components/RouterDetailsModal/RouterDetailsModal";
+
+export const useRouterDetailsModal = () => {
+  const [selectedRouter, setSelectedRouter] = useState<RouterItem | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleRowClick = (router: RouterItem) => {
+    setSelectedRouter(router);
+    setIsModalOpen(true);
+  };
+
+  const renderRouterDetailsModal = (
+    <RouterDetailsModal
+      open={isModalOpen}
+      onClose={() => setIsModalOpen(false)}
+      router={selectedRouter}
+    />
+  );
+
+  return {
+    selectedRouter,
+    isModalOpen,
+    handleRowClick,
+    renderRouterDetailsModal,
+  };
+};


### PR DESCRIPTION
The following PR contains: 
- Router details modal splitted to three types support rendering all the data over row click at the routers table.